### PR TITLE
faster implementation of Z_to_symbol

### DIFF
--- a/NatToSymbol.v
+++ b/NatToSymbol.v
@@ -1,6 +1,8 @@
 Require Import List Ascii Omega.
 Import ListNotations.
 
+Require Import Psatz.
+
 From PrettyParsing Require Import LexicalConsiderations.
 From StructTact Require Import StructTactics BoolUtil.
 
@@ -10,6 +12,23 @@ Fixpoint inc_digits (base : nat) (l : list nat) : list nat :=
   | d :: l => if base =? (S d) then 0 :: inc_digits base l
              else S d :: l
   end.
+
+Fixpoint double_digits' (base : nat) (l : list nat) (carry : nat) : list nat :=
+  match l with
+  | [] =>
+          match carry with
+          | 0 => []
+          | _ => [carry]
+          end
+  | d :: l =>
+          let d' := 2 * d + carry in
+          if base <=? d'
+              then d' - base :: double_digits' base l 1
+              else d' :: double_digits' base l 0
+  end.
+
+Definition double_digits (base : nat) (l : list nat) : list nat :=
+    double_digits' base l 0.
 
 Fixpoint digits' (base : nat) (acc : list nat) (n : nat) : list nat :=
   match n with
@@ -83,6 +102,33 @@ Proof.
     + auto.
 Qed.
 
+Lemma double_digits'_in_bounds :
+  forall base acc carry d,
+    (forall d, In d acc -> 0 <= d < base) ->
+    2 <= base ->
+    0 <= carry < 2 ->
+    In d (double_digits' base acc carry) ->
+    0 <= d < base.
+Proof.
+  induction acc; simpl; intros.
+  - break_match; simpl in *; intuition.
+  - break_match; simpl in *; break_or_hyp.
+    + do_bool. specialize (H a (or_introl eq_refl)). lia.
+    + eapply IHacc with (carry := 1); eauto.
+    + do_bool. specialize (H a (or_introl eq_refl)). lia.
+    + eapply IHacc with (carry := 0); eauto.
+Qed.
+
+Lemma double_digits_in_bounds :
+  forall base acc d,
+    (forall d, In d acc -> 0 <= d < base) ->
+    2 <= base ->
+    In d (double_digits base acc) ->
+    0 <= d < base.
+Proof.
+  intros. unfold double_digits in *. eauto using double_digits'_in_bounds.
+Qed.
+
 Lemma digits'_in_bounds :
   forall n base acc,
     2 <= base ->
@@ -114,6 +160,13 @@ Proof.
   destruct acc; simpl.
   - discriminate.
   - break_if; discriminate.
+Qed.
+
+Lemma double_digits_nonempty :
+  forall base l, l <> [] -> double_digits base l <> [].
+Proof.
+  destruct l; intros; try (exfalso; congruence).
+  cbn. break_if; simpl; discriminate.
 Qed.
 
 Lemma digits'_nonempty :
@@ -171,6 +224,30 @@ Proof.
     + omega.
 Qed.
 
+Lemma from_digits_double_digits' :
+  forall base l carry,
+    from_digits base (double_digits' base l carry) = carry + 2 * (from_digits base l).
+Proof.
+  induction l; simpl; intros.
+  - destruct carry; simpl; omega.
+  - break_if; simpl in *.
+    + rewrite IHl.
+      repeat rewrite Nat.mul_add_distr_l.  rewrite Nat.mul_1_r.
+      eapply leb_true_le in Heqb.
+      omega.
+    + rewrite IHl.
+      repeat rewrite Nat.mul_add_distr_l.
+      eapply leb_false_lt in Heqb.
+      omega.
+Qed.
+
+Lemma from_digits_double_digits :
+  forall base l,
+    from_digits base (double_digits base l) = 2 * (from_digits base l).
+Proof.
+  intros. unfold double_digits. rewrite from_digits_double_digits'. omega.
+Qed.
+
 Lemma from_digits_digits':
   forall base n acc, from_digits base (digits' base acc n) = n + from_digits base acc.
 Proof.
@@ -214,17 +291,178 @@ Proof.
   rewrite nat_ascii_embedding; omega.
 Qed.
 
+
+
+Fixpoint pos_digits (base : nat) (p : positive) : list nat :=
+    match p with
+    | xH => [1]
+    | xO p => double_digits base (pos_digits base p)
+    | xI p => inc_digits base (double_digits base (pos_digits base p))
+    end.
+
+Lemma pos_digits_in_bounds :
+  forall p base d,
+    2 <= base ->
+    In d (pos_digits base p) ->
+    0 <= d < base.
+Proof.
+  induction p; simpl; intros.
+  - eapply inc_digits_in_bounds; cycle 1; eauto.
+    intros. eapply double_digits_in_bounds; eauto.
+  - eapply double_digits_in_bounds; eauto.
+  - break_or_hyp; try contradiction. lia.
+Qed.
+
+Lemma pos_digits_non_empty :
+  forall base p, pos_digits base p <> [].
+Proof.
+  induction p; simpl.
+  - eapply inc_digits_nonempty.
+  - eapply double_digits_nonempty. auto.
+  - discriminate.
+Qed.
+
 Definition pos_to_symbol (p : positive) : symbol.t :=
-  nat_to_symbol (Pos.to_nat p).
+  List.map decimal_digit_to_ascii (List.rev (pos_digits 10 p)).
 
-Definition pos_from_symbol (s : symbol.t) : positive :=
-  Pos.of_nat (nat_from_symbol s).
-
-Lemma pos_to_from_symbol : forall p, pos_from_symbol (pos_to_symbol p) = p.
+Lemma rev_eq_nil : forall A (l : list A), rev l = [] -> l = [].
 Proof.
   intros.
+  rewrite <- rev_involutive with (l := l).
+  rewrite H. reflexivity.
+Qed.
+
+Lemma pos_to_symbol_wf :
+  forall p,
+    symbol.wf (pos_to_symbol p).
+Proof.
+  unfold pos_to_symbol.
+  intros.
+  apply wf_map.
+  - apply Forall_forall. intros d H.
+    apply decimal_digit_to_ascii_not_reserved.
+    eapply in_rev in H.
+    eapply pos_digits_in_bounds; eauto. omega.
+  - assert (pos_digits 10 p <> []) by apply pos_digits_non_empty.
+    contradict H. eauto using rev_eq_nil.
+Qed.
+
+Lemma pos_to_symbol_non_empty :
+  forall p, pos_to_symbol p <> [].
+Proof.
+  intros.
+  unfold pos_to_symbol.
+  intro H.
+  apply map_eq_nil in H.
+  apply rev_eq_nil in H.
+  eapply pos_digits_non_empty. eauto.
+Qed.
+
+Lemma pos_to_symbol_in_bounds :
+  forall p c, In c (pos_to_symbol p) -> 48 <= nat_of_ascii c < 58.
+Proof.
+  unfold pos_to_symbol.
+  intros.
+  apply in_map_iff in H.
+  break_exists. break_and.
+  apply in_rev in H0.
+  apply pos_digits_in_bounds in H0; try omega.
+  unfold decimal_digit_to_ascii in *.
+  subst c.
+  rewrite nat_ascii_embedding; omega.
+Qed.
+
+(* return `None` when the input is zero *)
+Fixpoint pos_from_digits (base : positive) (l : list nat) : option positive :=
+    match l with
+    | [] => None
+    | 0 :: l =>
+            match pos_from_digits base l with
+            | None => None
+            | Some x => Some (base * x)%positive
+            end
+    | S d :: l =>
+            match pos_from_digits base l with
+            | None => Some (Pos.of_succ_nat d)
+            | Some x => Some (Pos.of_succ_nat d + base * x)%positive
+            end
+    end.
+
+Lemma pos_from_digits_nat : forall base1 l,
+    let base := S base1 in
+    2 <= base ->
+    pos_from_digits (Pos.of_succ_nat base1) l =
+    match from_digits base l with
+    | 0 => None
+    | S n => Some (Pos.of_succ_nat n)
+    end.
+Proof.
+  induction l; intros; cbn.
+  - reflexivity.
+  - rewrite IHl by eauto. unfold base.
+    destruct a, (from_digits _ l); simpl in *.
+    + rewrite Nat.mul_0_r. reflexivity.
+    + f_equal. lia.
+    + rewrite Nat.mul_0_r. simpl. reflexivity.
+    + f_equal. lia.
+Qed.
+
+Lemma pos_from_digits_inc_digits : forall base1 l p,
+    let base := S base1 in
+    2 <= base ->
+    pos_from_digits (Pos.of_succ_nat base1) l = Some p ->
+    pos_from_digits (Pos.of_succ_nat base1) (inc_digits base l) = Some (Pos.succ p).
+Proof.
+  intros.
+  rewrite pos_from_digits_nat in *; eauto. rewrite from_digits_inc_digits.
+  unfold base. break_match_hyp; simpl.
+  - discriminate.
+  - invc H0. reflexivity.
+Qed.
+
+Lemma pos_from_digits_double_digits : forall base1 l p,
+    let base := S base1 in
+    2 <= base ->
+    pos_from_digits (Pos.of_succ_nat base1) l = Some p ->
+    pos_from_digits (Pos.of_succ_nat base1) (double_digits base l) = Some (2 * p)%positive.
+Proof.
+  intros.
+  rewrite pos_from_digits_nat in *; eauto. rewrite from_digits_double_digits.
+  unfold base. break_match_hyp; simpl.
+  - discriminate.
+  - invc H0. f_equal. lia.
+Qed.
+
+Lemma pos_from_digits_digits : forall base1 p,
+    let base := S base1 in
+    2 <= base ->
+    pos_from_digits (Pos.of_succ_nat base1) (pos_digits base p) = Some p.
+Proof.
+  induction p; intros.
+  - cbn.
+    erewrite pos_from_digits_inc_digits with (p := (p~0)%positive); eauto.
+    erewrite pos_from_digits_double_digits with (p := p); eauto.
+  - cbn.
+    erewrite pos_from_digits_double_digits with (p := p); eauto.
+  - cbn.
+    reflexivity.
+Qed.
+
+Definition pos_from_symbol (s : symbol.t) :=
+  pos_from_digits 10 (List.rev (List.map ascii_to_decimal_digit s)).
+
+Lemma pos_to_from_symbol : forall p, pos_from_symbol (pos_to_symbol p) = Some p.
+Proof.
   unfold pos_to_symbol, pos_from_symbol.
-  now rewrite nat_to_from_symbol, Pos2Nat.id.
+  intros.
+  rewrite map_map.
+  erewrite map_ext_in.
+  - change 10%positive with (Pos.of_succ_nat 9).
+    rewrite map_id, rev_involutive, pos_from_digits_digits; eauto. lia.
+  - intros. rewrite decimal_digit_to_from_ascii; auto.
+    eapply pos_digits_in_bounds.
+    + lia.
+    + eapply in_rev. eauto.
 Qed.
 
 Definition Z_to_symbol (z : Z) : symbol.t :=
@@ -238,204 +476,32 @@ Definition Z_from_symbol (s : symbol.t) : Z :=
   match s with
   | [] => 0%Z (* bogus! *)
   | c :: s' =>
-    if ascii_dec c "0" then 0%Z
-    else if ascii_dec c "-" then Zneg (pos_from_symbol s')
-    else Zpos (pos_from_symbol s)
+          if ascii_dec c "-" then
+            match pos_from_symbol s' with
+            | None => 0%Z
+            | Some p => Zneg p
+            end
+          else
+            match pos_from_symbol s with
+            | None => 0%Z
+            | Some p => Zpos p
+            end
   end.
-
-Lemma inc_digits_non_empty :
-  forall l,
-    inc_digits 10 l <> [].
-Proof.
-  destruct l; simpl.
-  - congruence.
-  - repeat break_match; congruence.
-Qed.
-
-Lemma digits'_10_non_empty :
-  forall n acc, acc <> [] -> digits' 10 acc n <> [].
-Proof.
-  induction n; simpl; intros.
-  - auto.
-  - apply IHn. apply inc_digits_nonempty.
-Qed.
-
-Lemma digits_10_non_empty :
-  forall n, digits 10 n <> [].
-Proof.
-  intros.
-  unfold digits.
-  destruct (digits' 10 [0] n) eqn:?.
-  - intro. eapply digits'_10_non_empty; eauto. congruence.
-  - simpl. intro H. apply app_eq_nil in H. intuition congruence.
-Qed.
-
-Lemma nat_to_symbol_non_empty :
-  forall n, nat_to_symbol n <> [].
-Proof.
-  intros.
-  unfold nat_to_symbol.
-  intro H.
-  apply map_eq_nil in H.
-  eapply digits_10_non_empty; eauto.
-Qed.
-
-Lemma pos_to_symbol_non_empty :
-  forall p, pos_to_symbol p <> [].
-Proof.
-  intros.
-  unfold pos_to_symbol.
-  apply nat_to_symbol_non_empty.
-Qed.
-
-
-  Lemma inc_digits_does_not_end_with_0 :
-    forall l d p,
-      (forall d p, l = p ++ [d] -> d = 0 -> False) ->
-      inc_digits 10 l = p ++ [d] -> d = 0 -> False.
-  Proof.
-    induction l; simpl; intros.
-    - destruct p; simpl in *; try congruence.
-      destruct p; simpl in *; congruence.
-    - set (b := match a with
-                | 0 => false
-                | 1 => false
-                | 2 => false
-                | 3 => false
-                | 4 => false
-                | 5 => false
-                | 6 => false
-                | 7 => false
-                | 8 => false
-                | 9 => true
-                | S (S (S (S (S (S (S (S (S (S _))))))))) => false
-                end) in *.
-      destruct b eqn:? in *.
-      + repeat (destruct a; try discriminate).
-        destruct p; simpl in *; invc H0.
-        * apply inc_digits_nonempty in H4. intuition.
-        * apply IHl in H4; auto.
-          intros.
-          eapply H with (d := d) (p := 9 :: _).
-          subst. simpl. eauto. auto.
-      + destruct p; simpl in *; invc H0.
-        * discriminate.
-        * eapply H with (p0 := _ :: _). simpl. eauto. auto.
-  Qed.
-
-Lemma digits'_10_does_not_end_with_0 :
-  forall n acc d p,
-    (forall d p, acc = p ++ [d] -> d = 0 -> False) ->
-    digits' 10 acc n = p ++ [d] ->
-    d = 0 ->
-    False.
-Proof.
-  induction n; simpl; intros.
-  - eauto.
-  - eapply IHn; [| apply H0|]; auto.
-    eauto using inc_digits_does_not_end_with_0.
-Qed.
-
-Lemma digits_10_does_not_start_with_0 :
-  forall n d l,
-    n <> 0 ->
-    digits 10 n = d :: l ->
-    d = 0 ->
-    False.
-Proof.
-  unfold digits.
-  intros.
-  apply f_equal with (f := @rev _) in H0.
-  rewrite rev_involutive in *.
-  simpl in *.
-  destruct n.
-  - congruence.
-  - simpl in H0.
-    eapply digits'_10_does_not_end_with_0 in H0; auto.
-    intros.
-    repeat (destruct p; simpl in *; try congruence).
-Qed.
-
-Lemma nat_to_symbol_does_not_start_with_0 :
-  forall n c s,
-    n <> 0 ->
-    nat_to_symbol n = c :: s ->
-    c = "0"%char ->
-    False.
-Proof.
-  unfold nat_to_symbol.
-  intros.
-  destruct (digits 10 n) eqn:? in *; simpl in *; invc H0.
-  eapply digits_10_does_not_start_with_0 in Heql; auto.
-
-  pose proof (digits_in_bounds n 10 n0 ltac:(omega)).
-  rewrite Heql in *. simpl in *.
-  specialize (H0 (or_introl eq_refl)).
-  do 10 try destruct n0; simpl in H3; try discriminate.
-  - auto.
-  - omega.
-Qed.
-
-Lemma pos_to_symbol_does_not_start_with_0 :
-  forall p c s,
-    pos_to_symbol p = c :: s ->
-    c = "0"%char ->
-    False.
-Proof.
-  unfold pos_to_symbol.
-  intros.
-  eapply nat_to_symbol_does_not_start_with_0; try exact H; auto.
-  pose proof (Pos2Nat.is_pos p). omega.
-Qed.
-
-Lemma nat_to_symbol_does_not_start_with_minus :
-  forall n c s,
-    nat_to_symbol n = c :: s ->
-    c = "-"%char ->
-    False.
-Proof.
-  unfold nat_to_symbol.
-  intros.
-  destruct (digits 10 n) eqn:? in *; simpl in *; invc H.
-  pose proof (digits_in_bounds n 10 n0 ltac:(omega)).
-  rewrite Heql in *. simpl in *.
-  specialize (H (or_introl eq_refl)).
-  do 10 try destruct n0; simpl in H2; try discriminate.
-  omega.
-Qed.
-
-Lemma pos_to_symbol_does_not_start_with_minus :
-  forall p c s,
-    pos_to_symbol p = c :: s ->
-    c = "-"%char ->
-    False.
-Proof.
-  unfold pos_to_symbol.
-  intros.
-  eapply nat_to_symbol_does_not_start_with_minus; try exact H; auto.
-Qed.
-
 
 Lemma Z_to_from_symbol : forall z, Z_from_symbol (Z_to_symbol z) = z.
 Proof.
-  intros.
-  unfold Z_from_symbol, Z_to_symbol.
-  destruct z; simpl; auto.
+  intros. unfold Z_from_symbol, Z_to_symbol.
+  destruct z; simpl.
+  - reflexivity.
   - break_match.
-    + now apply pos_to_symbol_non_empty in Heqt.
-    + break_if.
-      * exfalso. eapply pos_to_symbol_does_not_start_with_0; eauto.
-      * break_if.
-        -- exfalso. eapply pos_to_symbol_does_not_start_with_minus; eauto.
-        -- now rewrite <- Heqt, pos_to_from_symbol.
-  - now rewrite pos_to_from_symbol.
-Qed.
-
-Lemma pos_to_symbol_wf :
-  forall p, symbol.wf (pos_to_symbol p).
-Proof.
-  unfold pos_to_symbol.
-  auto using nat_to_symbol_wf.
+      { exfalso. eapply pos_to_symbol_non_empty. eauto. }
+    break_if.
+      { exfalso.
+        cut (48 <= nat_of_ascii "-" < 58).
+          { unfold nat_of_ascii. simpl. intro. lia. }
+        eapply pos_to_symbol_in_bounds. subst a. erewrite Heqt. simpl. auto. }
+    rewrite <- Heqt. rewrite pos_to_from_symbol. reflexivity.
+  - rewrite pos_to_from_symbol. reflexivity.
 Qed.
 
 Lemma Z_to_symbol_wf :


### PR DESCRIPTION
The previous implementation used `nat_to_symbol` internally, so running time was exponential in the number of bits in the `Z`.  This new implementation is only quadratic in the number of bits.